### PR TITLE
Fixed logic with isDisabled return value.

### DIFF
--- a/lib/Drupal/drupal_helpers/System.php
+++ b/lib/Drupal/drupal_helpers/System.php
@@ -79,7 +79,7 @@ class System {
    *   TRUE if the item is disabled, FALSE otherwise.
    */
   public static function isDisabled($name, $type = 'module') {
-    return self::isEnabled($name, $type);
+    return !self::isEnabled($name, $type);
   }
 
   /**


### PR DESCRIPTION
isDisabled() was returning TRUE when a module was enabled and FALSE when a module was disabled. I'm assuming this is meant to be the other way round?
