### PR TITLE
Document usage with imported namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Usage
 Dependencies
 ------------
 
-- [X Autoload ](https://www.drupal.org/project/xautoload)
+- [X Autoload](https://www.drupal.org/project/xautoload)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Drupal Helpers
+Drupal Helpers
+==============
 
 A library of Drupal-related PHP helpers for Drupal 7 core and contrib modules.
 
 [![Circle CI](https://circleci.com/gh/nicksantamaria/drupal_helpers.svg?style=svg)](https://circleci.com/gh/nicksantamaria/drupal_helpers)
 
-## Functionality Provided
+Functionality
+-------------
 
 * Bean
   * Create or load a bean.
@@ -41,7 +43,8 @@ A library of Drupal-related PHP helpers for Drupal 7 core and contrib modules.
 	* Recursively remove empty elements from array.
 	* Retrieve array column.
 
-## Examples
+Usage
+-----
 
 **Enable a module**
 ```php
@@ -58,6 +61,7 @@ A library of Drupal-related PHP helpers for Drupal 7 core and contrib modules.
 \Drupal\drupal_helpers\General::messageSet('My message');
 ```
 
-## Dependencies
+Dependencies
+------------
 
 - [X Autoload ](https://www.drupal.org/project/xautoload)

--- a/README.md
+++ b/README.md
@@ -46,19 +46,33 @@ Functionality
 Usage
 -----
 
-**Enable a module**
-```php
-\Drupal\drupal_helpers\Module::enable('views');
-```
+Use the Drupal helpers classes to perform common tasks during your Drupal module updates.
 
-**Revert a feature**
 ```php
-\Drupal\drupal_helpers\Feature::revert('mysite_feature');
-```
+<?php
 
-**Set message**
-```php
-\Drupal\drupal_helpers\General::messageSet('My message');
+/**
+ * @file
+ * example.install uninstall and update implementations.
+ */
+
+use Drupal\drupal_helpers\Module;
+use Drupal\drupal_helpers\Feature;
+use Drupal\drupal_helpers\General;
+
+/**
+ * Enable Views and Revert 'mysite' features.
+ */
+function example_update_7001 () {
+  // Enable views.
+  Module::enable('views');
+
+  // Revert mysite features.
+  Feature::revert('mysite_features');
+
+  // Print My message.
+  General::messageSet('My message');
+}
 ```
 
 Dependencies

--- a/drupal_helpers.info
+++ b/drupal_helpers.info
@@ -1,6 +1,6 @@
 name = Drupal Helpers
 description = Collection of helper functions and classes.
-php = 5.3
+php = 5.4
 core = 7.x
 
 dependencies[] = xautoload (>= 7.x-4.0)

--- a/lib/Drupal/drupal_helpers/Utility.php
+++ b/lib/Drupal/drupal_helpers/Utility.php
@@ -73,7 +73,7 @@ class Utility {
           }
           // Column is set, but does not exist.
           else {
-            throw new Exception(format_string('Column @column does not exist', [
+            throw new \Exception(format_string('Column @column does not exist', [
               '@column' => $column,
             ]));
           }


### PR DESCRIPTION
Show Drupal developers how to properly import the `drupal_helpers` namespace into their install file for use in `hook_update_N` implementations and other installer hooks.
