### PR TITLE
Remove git and CI config from module download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Ignore files for distribution archives.
+
+.gitattributes            export-ignore
+.gitignore                export-ignore
+.circle.yml               export-ignore
+.dcr.yml                  export-ignore


### PR DESCRIPTION
## Proposed Changes

- Add a `.gitattributes` config file
- Ignore CircleCI and Git config files when creating an archive for download

## Motivation

Ensure that only required code and documentation is included in any release distribution from Drupal or Packagist.