### PR TITLE
Field: change text field max length

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Functionality
 * Field
   * Delete a field.
   * Delete an instance of a field.
+  * Get and Set field configurations.
+  * Change the max length of a Text field that contains content.
 * Form
   * Get default values from the form.
 * General

--- a/lib/Drupal/drupal_helpers/Field.php
+++ b/lib/Drupal/drupal_helpers/Field.php
@@ -173,4 +173,81 @@ class Field {
     return ($result->rowCount() > 0);
   }
 
+  /**
+   * Change Text Field Max Length.
+   *
+   * Change the max length of a Text field, even if it contains content. Any
+   * text content longer than the new max length will be trimmed permanently.
+   *
+   * All changes are rolled back if there is a failure.
+   *
+   * @param string $field_name
+   *   Field name.
+   * @param int $max_length
+   *   Field length in characters.
+   *
+   * @throws \Exception
+   */
+  public static function changeTextFieldMaxLength($field_name, $max_length) {
+    $db_txn = db_transaction();
+
+    try {
+      // Modify field data and revisions.
+      foreach (['field_data', 'field_revision'] as $prefix) {
+        self::modifyTextFieldValueLength("{$prefix}_{$field_name}", $max_length);
+      }
+      // Update field config.
+      self::updateTextFieldConfigMaxLength($field_name, $max_length);
+    }
+    catch (Exception $e) {
+      // Something went wrong, so roll back all changes.
+      $db_txn->rollback();
+
+      // Pass on the exception with an explanation.
+      $message = sprintf(
+        'Failed to change field %s max length to %d : %s',
+        $field_name, $max_length, $e->getMessage()
+      );
+      throw new Exception($message, $e->getCode(), $e);
+    }
+  }
+
+  /**
+   * Modify a Text Field Table Value Column Length.
+   *
+   * @param string $field_table
+   *   Drupal field table name (ie. field_data_field_textfield).
+   * @param int $value_length
+   *   Length in characters.
+   */
+  private static function modifyTextFieldValueLength($field_table, $value_length) {
+    $field_value_column = $field_table . '_value';
+    $query_alter = sprintf(
+      'ALTER TABLE {%s} MODIFY %s VARCHAR(%d)',
+      $field_table, $field_value_column, $value_length
+    );
+    db_query($query_alter);
+  }
+
+  /**
+   * Update Text Field Configuration for Max Length.
+   *
+   * @param string $field_name
+   *   Text field name.
+   * @param int $max_length
+   *   Field length in characters.
+   *
+   * @throws \Exception
+   */
+  private static function updateTextFieldConfigMaxLength($field_name, $max_length) {
+    $config = self::getFieldConfigData($field_name);
+    if (is_array($config)) {
+      $config['settings']['max_length'] = $max_length;
+      self::setFieldConfigData($field_name, $config);
+    }
+    else {
+      throw new Exception(sprintf('No config data found for field %s', $field_name));
+    }
+  }
+
 }

--- a/lib/Drupal/drupal_helpers/Field.php
+++ b/lib/Drupal/drupal_helpers/Field.php
@@ -140,4 +140,37 @@ class Field {
     return FALSE;
   }
 
+  /**
+   * Set Field Configuration Data.
+   *
+   * @param string $field_name
+   *   Field name.
+   * @param array $config
+   *   Field configuration array.
+   *
+   * @return bool
+   *   Success TRUE else FALSE.
+   *
+   * @throws \Exception
+   */
+  public static function setFieldConfigData($field_name, array $config) {
+    try {
+      $data = serialize($config);
+      $result = db_update('field_config')
+        ->fields(['data' => $data])
+        ->condition('field_name', $field_name)
+        ->execute();
+    }
+    catch (Exception $e) {
+      // Pass on the exception with an explanation.
+      $message = sprintf(
+        'Failed to set field config data for %s : %s',
+        $field_name, $e->getMessage()
+      );
+      throw new Exception($message, $e->getCode(), $e);
+    }
+
+    return ($result->rowCount() > 0);
+  }
+
 }

--- a/lib/Drupal/drupal_helpers/Field.php
+++ b/lib/Drupal/drupal_helpers/Field.php
@@ -103,4 +103,41 @@ class Field {
     General::messageSet($t($message, $replacements));
   }
 
+  /**
+   * Get Field Configuration Data.
+   *
+   * @param string $field_name
+   *   Field name.
+   *
+   * @return array|bool
+   *   Field configuration array else FALSE.
+   *
+   * @throws \Exception
+   */
+  public static function getFieldConfigData($field_name) {
+    try {
+      $query = '
+        SELECT CAST(data AS CHAR(10000) CHARACTER SET utf8)
+        FROM {field_config}
+        WHERE field_name = :field_name
+      ';
+      $result = db_query($query, [':field_name' => $field_name]);
+      $config = $result->fetchField();
+    }
+    catch (Exception $e) {
+      // Pass on the exception with an explanation.
+      $message = sprintf(
+        'Failed to get field config data for %s : %s',
+        $field_name, $e->getMessage()
+      );
+      throw new Exception($message, $e->getCode(), $e);
+    }
+
+    if ($config) {
+      return unserialize($config);
+    }
+
+    return FALSE;
+  }
+
 }

--- a/lib/Drupal/drupal_helpers/Field.php
+++ b/lib/Drupal/drupal_helpers/Field.php
@@ -210,6 +210,8 @@ class Field {
       );
       throw new Exception($message, $e->getCode(), $e);
     }
+
+    General::messageSet(sprintf('Text field %s max length changed to %d', $field_name, $max_length));
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes

Add methods to provide the following Field helpers:

1. Get and Set field config data
2. Change the max length of a Text field, even when it has stored data

## Motivation

I had a project where we needed to make the max length for some text fields longer, extending them from 150 to 255 chars. This cannot be done through the Drupal Field UI or Features when the field is shared and/or has data stored in it. However it is possible with some custom Database queries.
