### PR TITLE
Fixed Variables not being correctly stored/restored if not existing in DB.

### DIFF
--- a/lib/Drupal/drupal_helpers/Variable.php
+++ b/lib/Drupal/drupal_helpers/Variable.php
@@ -73,7 +73,12 @@ class Variable {
 
     $storage_values = variable_get($storage_key, []);
     foreach ($storage_values as $name => $value) {
-      variable_set($name, $value);
+      if (is_null($value)) {
+        variable_del($name);
+      }
+      else {
+        variable_set($name, $value);
+      }
     }
 
     variable_del($storage_key);
@@ -100,6 +105,10 @@ class Variable {
     foreach ($names as $name) {
       $all_names = array_merge($all_names, static::getNameWildcard($name, $variables));
     }
+
+    // If names where not found in DB - the variables have not been set, but
+    // we are still expecting provided names to be returned.
+    $all_names = !empty($all_names) ? $all_names : $names;
 
     return $all_names;
   }

--- a/tests/VariableTest.php
+++ b/tests/VariableTest.php
@@ -112,6 +112,23 @@ class VariableTestCase extends \PHPUnit_Framework_TestCase {
           'prefixnamesuffix',
         ],
       ],
+
+      [
+        'othername',
+        $data,
+        [
+          'othername',
+        ],
+      ],
+
+      [
+        ['othername', 'secondothername'],
+        $data,
+        [
+          'othername',
+          'secondothername',
+        ],
+      ],
     ];
   }
 


### PR DESCRIPTION
## Proposed Changes

Fixes an issue with `Variables` class not properly storing and restoring values for variables not set in DB.
