### PR TITLE
Fix SQL + PHP Errors in Field Resize Code

### DIFF
--- a/lib/Drupal/drupal_helpers/Field.php
+++ b/lib/Drupal/drupal_helpers/Field.php
@@ -194,7 +194,9 @@ class Field {
     try {
       // Modify field data and revisions.
       foreach (['field_data', 'field_revision'] as $prefix) {
-        self::modifyTextFieldValueLength("{$prefix}_{$field_name}", $max_length);
+        $table_name = "{$prefix}_{$field_name}";
+
+        self::modifyTextFieldValueLength($table_name, $field_name, $max_length);
       }
       // Update field config.
       self::updateTextFieldConfigMaxLength($field_name, $max_length);
@@ -217,16 +219,20 @@ class Field {
   /**
    * Modify a Text Field Table Value Column Length.
    *
-   * @param string $field_table
-   *   Drupal field table name (ie. field_data_field_textfield).
+   * @param string $table_name
+   *   The name of the table that contains the field.
+   * @param string $field_name
+   *   The name of the field being resized.
    * @param int $value_length
    *   Length in characters.
    */
-  private static function modifyTextFieldValueLength($field_table, $value_length) {
-    $field_value_column = $field_table . '_value';
+  private static function modifyTextFieldValueLength($table_name,
+                                                     $field_name,
+                                                     $value_length) {
+    $field_value_column = $field_name . '_value';
     $query_alter = sprintf(
       'ALTER TABLE {%s} MODIFY %s VARCHAR(%d)',
-      $field_table, $field_value_column, $value_length
+      $table_name, $field_value_column, $value_length
     );
     db_query($query_alter);
   }

--- a/lib/Drupal/drupal_helpers/Field.php
+++ b/lib/Drupal/drupal_helpers/Field.php
@@ -148,15 +148,14 @@ class Field {
    * @param array $config
    *   Field configuration array.
    *
-   * @return bool
-   *   Success TRUE else FALSE.
-   *
    * @throws \Exception
+   *   If the update request fails.
    */
   public static function setFieldConfigData($field_name, array $config) {
     try {
       $data = serialize($config);
-      $result = db_update('field_config')
+
+      db_update('field_config')
         ->fields(['data' => $data])
         ->condition('field_name', $field_name)
         ->execute();
@@ -169,8 +168,6 @@ class Field {
       );
       throw new Exception($message, $e->getCode(), $e);
     }
-
-    return ($result->rowCount() > 0);
   }
 
   /**


### PR DESCRIPTION
This PR closes #39, as follows:

-  Fixes Field Naming Conventions for Field Resize: Drupal's convention is to name fields `field_X_value` in a _table_ called `field_data_field_X`; the code was previously assuming that the value field was `field_data_field_X_value`, which is not correct. The name of the field is shorter than the table name (presumably to make more characters available for longer field names on MySQL).
- Stops Making `setFieldConfigData()` return Boolean
  - `db_update()->execute()` returns the number of records affected, not a result object.
  - Even if the update query returns 0, that does not mean the update was a failure -- the new size might have matched the old size of the field. It does not make sense for the function to use the number of records affected as a measure of success.
  - If something goes wrong with the update, an exception is thrown by PDO, so there's already a way to detect failure.
  - Nothing in the previous code actually seems to care about the return value of `setFieldConfigData()`.

