### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,19 +4,21 @@
     "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,
-    "major": {
-        "enabled": false
-    },
-    "groupName": "all dependencies",
-    "groupSlug": "all",
     "branchPrefix": "deps/",
-    "composer": {
-        "managerFilePatterns": ["/composer\\.dev\\.json$/"]
-    },
     "packageRules": [
         {
+            "matchDepNames": ["php"],
             "matchManagers": ["composer"],
-            "matchFileNames": ["composer.json"],
+            "enabled": false
+        },
+        {
+            "matchDepNames": ["node", "yarn"],
+            "matchManagers": ["npm"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm", "composer"],
+            "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {


### PR DESCRIPTION
Updated renovate config via 🤠 RepoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Renovate Configuration Update

Updated the Renovate configuration to refine dependency management rules:

### Changes Made

- **Removed top-level configuration fields**: `major.enabled`, `groupName`, `groupSlug`, and the `composer` block were removed from the root configuration
- **Added package rules for disabling specific dependencies**:
  - PHP dependencies via Composer are now disabled (`matchDepNames: ["php"]`, `matchManagers: ["composer"]`, `enabled: false`)
  - Node and Yarn dependencies via npm are now disabled (`matchDepNames: ["node", "yarn"]`, `matchManagers: ["npm"]`, `enabled: false`)
- **Added rule to disable major updates** for both npm and Composer dependencies (`matchManagers: ["npm", "composer"]`, `matchUpdateTypes: ["major"]`, `enabled: false`)
- **Retained the existing rule** that groups all dependencies under "all dependencies"

### Impact

These changes streamline the Renovate configuration by centralizing dependency update rules through `packageRules` instead of top-level configuration fields, while maintaining control over major version updates and preventing automatic updates to PHP and Node versions.

Lines changed: +11/-9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->