### PR TITLE
Updated scaffold to 4.17.0.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -66,6 +66,8 @@ commands:
       ahoy title "Running Twig CS Fixer"
       vendor/bin/twig-cs-fixer
       popd >/dev/null || exit 1
+      ahoy title "Running docs check"
+      php docs.php --fail-on-change
 
   lint-fix:
     usage: Fix violations in coding standards.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -29,12 +29,17 @@ commands:
     usage: Stop development environment.
     cmd: ./.devtools/stop
 
+  info:
+    usage: Print a read-only summary of the current environment.
+    aliases: [describe]
+    cmd: ./.devtools/info
+
   debug:
     usage: Enable PHP XDebug step-debugging for the development server.
     aliases: [debug-on, xdebug, xdebug-on]
     cmd: |
-      ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
-      (XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$(lsof -ti:${WEBSERVER_PORT:-8000} 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+      [ "$(./.devtools/info xdebug)" = "enabled" ] && echo "XDebug is already enabled. Run 'ahoy start' to disable." || \
+      (XDEBUG=1 ./.devtools/start && sleep 1 && [ "$(./.devtools/info xdebug)" = "enabled" ] && echo "Enabled XDebug. Run 'ahoy start' to disable." || (echo "Failed to enable XDebug." && exit 1))
 
   provision:
     usage: Provision application within assembled codebase.
@@ -61,8 +66,6 @@ commands:
       ahoy title "Running Twig CS Fixer"
       vendor/bin/twig-cs-fixer
       popd >/dev/null || exit 1
-      ahoy title "Running docs check"
-      php docs.php --fail-on-change
 
   lint-fix:
     usage: Fix violations in coding standards.
@@ -113,6 +116,7 @@ commands:
       php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
       popd >/dev/null || exit 1
 
+
   selenium-start:
     usage: Start Selenium container if not already running.
     cmd: |
@@ -135,6 +139,7 @@ commands:
 
   reset:
     usage: Reset project to the default state.
+    aliases: [delete, destroy]
     cmd: |
       killall -9 php >/dev/null 2>&1 || true
       chmod -Rf 777 build .logs > /dev/null 2>&1 || true
@@ -152,6 +157,9 @@ entrypoint:
   - -c
   - -e
   - |
+    # Resolve a relative TMPDIR to an absolute path so tools that chdir (pushd
+    # build) still find it. No-op when unset or already absolute.
+    if [ -n "${TMPDIR:-}" ]; then case "$TMPDIR" in /*) ;; *) TMPDIR="$PWD/$TMPDIR" ;; esac; mkdir -p "$TMPDIR"; export TMPDIR; fi
     extension="$(basename -s .info.yml -- ./*.info.yml)"
     export BROWSERTEST_OUTPUT_DIRECTORY="${TMPDIR:-/tmp}"
     export SIMPLETEST_BASE_URL=http://${WEBSERVER_HOST:-localhost}:${WEBSERVER_PORT:-8000}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+    "permissions": {
+        "allow": [
+            "Bash(ahoy:*)",
+            "Bash(composer:*)"
+        ],
+        "deny": []
+    }
+}

--- a/.devtools/README.md
+++ b/.devtools/README.md
@@ -9,4 +9,8 @@ This directory contains scripts used for development. These can be used locally 
 | `deploy`      | Mirror the extension to a remote git repository (e.g. drupal.org). Used in CI.                         |
 | `helpers.php` | Shared PHP utilities (dotenv read/write, port discovery, drush wrappers, filesystem helpers).          |
 
+## Custom scripts
+
+`assemble` and `provision` both look for `scripts/<prefix>-*.sh` in the project root and run any matches at the end of the phase. `assemble-*.sh` for post-assemble, `provision-*.sh` for post-provision. Scripts run in lexicographic order, inherit the parent environment, and a non-zero exit aborts the parent. See the "Custom assemble and provision scripts" section in the root `README.md` for the full convention.
+
 See the root `README.md` for higher-level workflow documentation.

--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -270,6 +270,9 @@ if (file_exists($build_dir . '/package-lock.json') && !file_exists('.skip_npm_bu
   PASS('Front-end dependencies processed.');
 }
 
+// Run custom post-assemble scripts from "scripts/assemble-*.sh", if any.
+run_custom_scripts('scripts', 'assemble-');
+
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo '    🏗 ASSEMBLE COMPLETE ✅   ' . PHP_EOL;

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -185,6 +185,113 @@ function dotenv_write_var(string $key, string $value, string $file = '.env'): vo
 }
 
 /**
+ * Resolve an environment value from env, then dotenv, then default.
+ *
+ * Mirrors the precedence chain used by the start, stop, provision, and
+ * info scripts: shell environment first, then a matching key in the
+ * dotenv file, then the supplied default. Returns the resolved value
+ * together with a source label identifying which leg of the chain
+ * produced it.
+ *
+ * @param string $name
+ *   Variable name to resolve.
+ * @param string $default
+ *   Value to return when neither env nor the dotenv file provides a
+ *   non-empty value. May be an empty string when callers want to
+ *   detect that case and apply their own fallback (for example,
+ *   start's auto-discovery branch).
+ * @param string $dotenv_file
+ *   Path to the dotenv file to consult.
+ *
+ * @return array{0: string, 1: string}
+ *   Tuple of [value, source] where source is 'env' when the value came
+ *   from the shell environment, the dotenv file path when the value
+ *   came from that file, or 'default' when neither produced a value.
+ */
+function resolve_env_value(string $name, string $default, string $dotenv_file = '.env'): array {
+  $env = getenv($name);
+  if ($env !== FALSE && $env !== '') {
+    return [$env, 'env'];
+  }
+
+  $dotenv = dotenv_read($dotenv_file);
+  if (isset($dotenv[$name]) && $dotenv[$name] !== '') {
+    return [$dotenv[$name], $dotenv_file];
+  }
+
+  return [$default, 'default'];
+}
+
+/**
+ * Resolve the webserver host and port with source tracking.
+ *
+ * Wraps resolve_env_value() for both 'WEBSERVER_HOST' and
+ * 'WEBSERVER_PORT'. Optionally auto-discovers a free port when neither
+ * env nor the dotenv file provides one, persisting the discovered port
+ * back to the dotenv file. Optionally validates that the resolved port
+ * is a valid TCP port number.
+ *
+ * @param bool $auto_discover
+ *   When TRUE and the port resolves from neither env nor dotenv,
+ *   discover a free port via find_free_port() and persist it via
+ *   dotenv_write_var(). The reported port source then becomes the
+ *   dotenv file path because that is where the value now lives.
+ * @param bool $validate_port
+ *   When TRUE, call validate_port_or_fail() on the resolved port and
+ *   abort if it is not a valid TCP port. The info script disables
+ *   this so a malformed value can be surfaced in the output rather
+ *   than crashing the read-only summary.
+ * @param string $dotenv_file
+ *   Path to the dotenv file to read and (optionally) write.
+ *
+ * @return array{host: string, host_source: string, port: string, port_source: string}
+ *   The resolved host and port together with the source label for
+ *   each: 'env' when the value came from the shell environment, the
+ *   dotenv file path when it came from that file, or 'default' when
+ *   the supplied default was used.
+ */
+function resolve_webserver(bool $auto_discover = FALSE, bool $validate_port = TRUE, string $dotenv_file = '.env'): array {
+  [$host, $host_source] = resolve_env_value('WEBSERVER_HOST', 'localhost', $dotenv_file);
+
+  $default_port = $auto_discover ? '' : '8000';
+  [$port, $port_source] = resolve_env_value('WEBSERVER_PORT', $default_port, $dotenv_file);
+
+  if ($auto_discover && $port_source === 'default') {
+    $port = (string) find_free_port();
+    dotenv_write_var('WEBSERVER_PORT', $port, $dotenv_file);
+    $port_source = $dotenv_file;
+  }
+
+  if ($validate_port) {
+    validate_port_or_fail($port, 'WEBSERVER_PORT');
+  }
+
+  return [
+    'host' => $host,
+    'host_source' => $host_source,
+    'port' => $port,
+    'port_source' => $port_source,
+  ];
+}
+
+/**
+ * Detect the XDebug state of the dev server listening on the given port.
+ *
+ * Inspects the running PHP process's command line for the
+ * 'xdebug.mode=debug' flag. Returns 'enabled' or 'disabled' when a
+ * server is listening, and '-' when no server is bound to the port.
+ */
+function xdebug_state(string $port): string {
+  $cmd = sprintf('ps -o command= -p "$(lsof -ti:%s 2>/dev/null | head -1)" 2>/dev/null', escapeshellarg($port));
+  $out = trim((string) @shell_exec($cmd));
+  if ($out === '') {
+    return '-';
+  }
+
+  return str_contains($out, 'xdebug.mode=debug') ? 'enabled' : 'disabled';
+}
+
+/**
  * Validate that a value is a TCP port in the range 1-65535.
  *
  * Calls FAIL() with a descriptive message if validation fails.
@@ -353,6 +460,45 @@ function passthru_or_fail(string $cmd, string $format = '', string|int|float ...
       FAIL($format, ...$args);
     }
     quit($exit_code);
+  }
+}
+
+/**
+ * Run custom shell scripts from a directory matching a filename prefix.
+ *
+ * Scripts are matched as "<dir>/<prefix>*.sh", sorted lexicographically,
+ * and executed in order. Each script runs with the current working
+ * directory as the parent process's CWD and inherits the parent's
+ * environment. A non-zero exit from any script aborts the parent.
+ *
+ * The directory and any matching scripts are optional: a missing
+ * directory or an empty match set returns silently. This is the
+ * post-assemble / post-provision extension point.
+ *
+ * @param string $dir
+ *   Directory to scan, relative to the current working directory.
+ * @param string $prefix
+ *   Filename prefix to match (e.g. "assemble-" or "provision-").
+ */
+function run_custom_scripts(string $dir, string $prefix): void {
+  if (!is_dir($dir)) {
+    return;
+  }
+
+  $files = glob($dir . '/' . $prefix . '*.sh') ?: [];
+  if ($files === []) {
+    return;
+  }
+
+  sort($files);
+
+  foreach ($files as $file) {
+    if (!is_file($file)) {
+      continue;
+    }
+    TASK("Running custom script '%s'.", $file);
+    passthru_or_fail(escapeshellarg($file), "Custom script '%s' failed.", $file);
+    PASS("Completed custom script '%s'.", $file);
   }
 }
 

--- a/.devtools/info
+++ b/.devtools/info
@@ -1,0 +1,156 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @file
+ * Print a read-only summary of the current development environment.
+ *
+ * Resolves PHP, Drupal, Composer, Drush, Node, and npm versions; the
+ * webserver host and port along with where each value was sourced from
+ * (shell env vs '.env' vs default); the running server's XDebug state;
+ * the build directory; the SQLite database path; and the active Drupal
+ * install profile.
+ *
+ * Any value that cannot be resolved prints '-' rather than failing.
+ *
+ * Two output modes:
+ * - No arguments: print the formatted full summary.
+ * - 'info <field>': print only that field's value on stdout, exit 0.
+ *   Unknown field name prints '-' and exits 1.
+ *
+ * Field-mode keeps expensive subprocess probes lazy: only the requested
+ * field's resolver runs.
+ */
+
+declare(strict_types=1);
+
+namespace DrupalExtensionScaffold\DevTools;
+
+require_once __DIR__ . '/helpers.php';
+
+// -----------------------------------------------------------------------------
+// Cheap resolutions (env + filesystem). Always run.
+// -----------------------------------------------------------------------------
+
+$webserver = resolve_webserver(validate_port: FALSE);
+$webserver_host = $webserver['host'];
+$host_source = $webserver['host_source'];
+$webserver_port = $webserver['port'];
+$port_source = $webserver['port_source'];
+
+$drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');
+
+$cwd = (string) getcwd();
+$build_dir = is_dir($cwd . '/build') ? $cwd . '/build' : '-';
+
+$info_files = glob('*.info.yml');
+$extension_name = (is_array($info_files) && $info_files !== []) ? basename($info_files[0], '.info.yml') : '';
+$db_file = $extension_name !== '' ? '/tmp/site_' . $extension_name . '.sqlite' : '-';
+
+$drush_bin = 'build/vendor/bin/drush';
+$has_drush = is_file($drush_bin);
+
+$site_url = sprintf('http://%s:%s', $webserver_host, $webserver_port);
+
+// -----------------------------------------------------------------------------
+// Field resolvers. Each closure is invoked only when its field is requested.
+// -----------------------------------------------------------------------------
+
+$fields = [
+  'drupal-version' => fn(): string => $has_drush ? info_drupal_version($drush_bin) : '-',
+  'php-version' => fn(): string => info_php_version(),
+  'composer' => fn(): string => info_tool_version('composer --version 2>/dev/null', '/Composer(?:\s+version)?\s+(\S+)/i'),
+  'drush' => fn(): string => $has_drush ? info_tool_version(escapeshellarg($drush_bin) . ' --version 2>/dev/null', '/(\d+\.\d+\.\d+)/') : '-',
+  'node' => fn(): string => info_tool_version('node --version 2>/dev/null', '/v?(.+)/'),
+  'npm' => fn(): string => info_tool_version('npm --version 2>/dev/null', '/(.+)/'),
+  'webserver-host' => fn(): string => $webserver_host,
+  'webserver-port' => fn(): string => $webserver_port,
+  'site-url' => fn(): string => $site_url,
+  'xdebug' => fn(): string => xdebug_state($webserver_port),
+  'build-dir' => fn(): string => $build_dir,
+  'database' => fn(): string => $db_file,
+  'drupal-profile' => fn(): string => $drupal_profile,
+];
+
+// -----------------------------------------------------------------------------
+// Field-mode dispatch.
+// -----------------------------------------------------------------------------
+
+$field = isset($argv[1]) && !str_starts_with((string) $argv[1], '-') ? (string) $argv[1] : NULL;
+if ($field !== NULL) {
+  if (isset($fields[$field])) {
+    echo $fields[$field]() . PHP_EOL;
+    quit(0);
+  }
+  echo '-' . PHP_EOL;
+  quit(1);
+}
+
+// -----------------------------------------------------------------------------
+// Full summary. Resolves every field then formats.
+// -----------------------------------------------------------------------------
+
+$values = array_map(fn(callable $cb): string => $cb(), $fields);
+$php_path = command_path('php');
+
+echo PHP_EOL;
+echo '===============================' . PHP_EOL;
+echo '       ENVIRONMENT INFO        ' . PHP_EOL;
+echo '===============================' . PHP_EOL;
+echo PHP_EOL;
+printf("Drupal version:     %s%s", $values['drupal-version'], PHP_EOL);
+printf("PHP version:        %s%s%s", $values['php-version'], $php_path !== FALSE && $values['php-version'] !== '-' ? ' (' . $php_path . ')' : '', PHP_EOL);
+printf("Composer:           %s%s", $values['composer'], PHP_EOL);
+printf("Drush:              %s%s", $values['drush'], PHP_EOL);
+printf("Node / npm:         %s / %s%s", $values['node'], $values['npm'], PHP_EOL);
+echo PHP_EOL;
+printf("Webserver host:     %s (%s)%s", $values['webserver-host'], $host_source, PHP_EOL);
+printf("Webserver port:     %s (%s)%s", $values['webserver-port'], $port_source, PHP_EOL);
+printf("Site URL:           %s%s", $values['site-url'], PHP_EOL);
+printf("XDebug:             %s%s", $values['xdebug'], PHP_EOL);
+echo PHP_EOL;
+printf("Build dir:          %s%s", $values['build-dir'], PHP_EOL);
+printf("Database:           %s%s", $values['database'], PHP_EOL);
+printf("Drupal profile:     %s%s", $values['drupal-profile'], PHP_EOL);
+echo PHP_EOL;
+
+// -----------------------------------------------------------------------------
+// Local helpers.
+// -----------------------------------------------------------------------------
+
+/**
+ * Get the host PHP version, or '-' if it cannot be parsed.
+ */
+function info_php_version(): string {
+  $out = (string) @shell_exec('php -v 2>/dev/null');
+  if ($out === '' || !preg_match('/^PHP\s+(\S+)/m', $out, $matches)) {
+    return '-';
+  }
+
+  return $matches[1];
+}
+
+/**
+ * Run a version probe and extract the first capture group.
+ *
+ * Returns '-' if the command produces no output or the pattern does
+ * not match.
+ */
+function info_tool_version(string $cmd, string $pattern): string {
+  $out = trim((string) @shell_exec($cmd));
+  if ($out === '' || !preg_match($pattern, $out, $matches)) {
+    return '-';
+  }
+
+  return trim($matches[1]);
+}
+
+/**
+ * Get the installed Drupal version via drush, or '-' if unavailable.
+ */
+function info_drupal_version(string $drush_bin): string {
+  $cmd = escapeshellarg($drush_bin) . ' -r ' . escapeshellarg(getcwd() . '/build/web') . ' status --field=drupal-version 2>/dev/null';
+  $out = trim((string) @shell_exec($cmd));
+
+  return $out === '' ? '-' : $out;
+}

--- a/.devtools/provision
+++ b/.devtools/provision
@@ -20,19 +20,11 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver hostname.
-$webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
-
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Default '8000'.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
-}
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver host and port resolved via the env -> '.env' -> default
+// chain.
+$webserver = resolve_webserver();
+$webserver_host = $webserver['host'];
+$webserver_port = $webserver['port'];
 
 // Drupal profile to use when installing the site.
 $drupal_profile = getenv_default('DRUPAL_PROFILE', 'standard');
@@ -93,6 +85,9 @@ PASS('Suggested modules enabled.');
 TASK('Pre-warming caches.');
 @file_get_contents(sprintf('http://%s:%s', $webserver_host, $webserver_port));
 PASS('Caches pre-warmed.');
+
+// Run custom post-provision scripts from "scripts/provision-*.sh", if any.
+run_custom_scripts('scripts', 'provision-');
 
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;

--- a/.devtools/start
+++ b/.devtools/start
@@ -16,25 +16,13 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver hostname.
-$webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
-
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Auto-discovery via find_free_port(), persisted to .env.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
-    $webserver_port = $dotenv['WEBSERVER_PORT'];
-  }
-  else {
-    $webserver_port = (string) find_free_port();
-    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
-  }
-}
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver host and port. The helper resolves both via the
+// env -> '.env' -> default chain. With auto_discover: TRUE, a free
+// port is allocated and persisted to '.env' when neither env nor
+// '.env' provides one.
+$webserver = resolve_webserver(auto_discover: TRUE);
+$webserver_host = $webserver['host'];
+$webserver_port = $webserver['port'];
 
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');

--- a/.devtools/stop
+++ b/.devtools/stop
@@ -16,16 +16,8 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver port. Resolution precedence:
-// 1. WEBSERVER_PORT env var, if set.
-// 2. WEBSERVER_PORT entry in .env, if present.
-// 3. Default '8000'.
-$webserver_port = getenv_default('WEBSERVER_PORT', '');
-if ($webserver_port === '') {
-  $dotenv = dotenv_read('.env');
-  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
-}
-validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
+// Webserver port resolved via the env -> '.env' -> default chain.
+$webserver_port = resolve_webserver()['port'];
 
 // -----------------------------------------------------------------------------
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,11 +16,6 @@ indent_size = 4
 [package.json]
 indent_size = 2
 
-[.eslintrc.json]
-indent_size = 2
-
-[.prettierrc.json]
-indent_size = 2
 
 [*.xml]
 indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,20 +7,14 @@ CLAUDE.md          export-ignore
 .circleci          export-ignore
 .devtools          export-ignore
 .editorconfig      export-ignore
-.eslintignore      export-ignore
-.eslintrc.json     export-ignore
 .gitattributes     export-ignore
 .github            export-ignore
 .gitignore         export-ignore
-.prettierignore    export-ignore
-.prettierrc.json   export-ignore
 .skip_npm_build    export-ignore
-.stylelintrc.js    export-ignore
 .twig-cs-fixer.php export-ignore
 Makefile           export-ignore
 composer.dev.json  export-ignore
 docs.php           export-ignore
-jest.config.js     export-ignore
 package-lock.json  export-ignore
 package.json       export-ignore
 patches            export-ignore
@@ -30,5 +24,6 @@ phpunit.d10.xml    export-ignore
 phpunit.xml        export-ignore
 rector.php         export-ignore
 renovate.json      export-ignore
+scripts            export-ignore
 tests              export-ignore
 

--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -7,11 +7,14 @@ on:
       - reopened
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   assign-author:
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Assign author

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
 
+    permissions:
+      contents: read
+
     env:
       DEPLOY_USER_NAME: ${{ secrets.DEPLOY_USER_NAME }}
       DEPLOY_USER_EMAIL: ${{ secrets.DEPLOY_USER_EMAIL }}
@@ -26,6 +29,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install SSH key
         uses: shimataro/ssh-key-action@6b84f2e793b32fa0b03a379cadadec75cc539391 # v2

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -8,7 +8,7 @@ on:
       - 2.x
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release-drafter:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,16 +26,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: ${{ github.event_name == 'push' && 'npm' || '' }}
-
-      - name: Install Node.js dependencies
-        run: npm ci --ignore-scripts
-
-
       - name: Cache Composer dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,24 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: ${{ github.event_name == 'push' && 'npm' || '' }}
+
+      - name: Install Node.js dependencies
+        run: npm ci --ignore-scripts
+
 
       - name: Cache Composer dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -58,88 +73,39 @@ jobs:
         run: vendor/bin/twig-cs-fixer
         continue-on-error: ${{ vars.CI_TWIGCSFIXER_IGNORE_FAILURE == '1' }}
 
+
   test:
     runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
 
       matrix:
         include:
-          - name: test-php-8.2-d10-legacy
+          - name: test-php-min-d10-stable
             php-version: 8.2
-            drupal-version: 10.2
+            drupal-version: 10
 
-          - name: test-php-8.2-d10-stable
-            php-version: 8.2
-            drupal-version: 10.3
-
-          - name: test-php-8.2-d10-canary
-            php-version: 8.2
-            drupal-version: 10.4@beta
-            stability: canary
-
-          - name: test-php-8.3-d10-legacy
-            php-version: 8.3
-            drupal-version: 10.2
-
-          - name: test-php-8.3-d10-stable
-            php-version: 8.3
-            drupal-version: 10.3
-
-          - name: test-php-8.3-d10-canary
-            php-version: 8.3
-            drupal-version: 10.4@beta
-            stability: canary
-
-          - name: test-php-8.4-d10-legacy
+          - name: test-php-max-d10-stable
             php-version: 8.4
-            drupal-version: 10.3 # Lowest Drupal version that supports PHP 8.4.
+            drupal-version: 10
 
-          - name: test-php-8.4-d10-stable
-            php-version: 8.4
-            drupal-version: 10.3
-
-          - name: test-php-8.4-d10-canary
-            php-version: 8.4
-            drupal-version: 10.4@beta
-            stability: canary
-
-          - name: test-php-8.3-d11-legacy
+          - name: test-php-min-d11-stable
             php-version: 8.3
-            drupal-version: 11.0 # Lowest Drupal version that exists.
+            drupal-version: 11
 
-          - name: test-php-8.3-d11-stable
-            php-version: 8.3
-            drupal-version: 11.0
-
-          - name: test-php-8.3-d11-canary
-            php-version: 8.3
-            drupal-version: 11@beta
-            stability: canary
-
-          - name: test-php-8.4-d11-legacy
-            php-version: 8.4
-            drupal-version: 11.0 # Lowest Drupal version that exists.
-
-          - name: test-php-8.4-d11-stable
-            php-version: 8.4
-            drupal-version: 11.0
-
-          - name: test-php-8.4-d11-canary
-            php-version: 8.4
-            drupal-version: 11@beta
-            stability: canary
-
-          - name: test-php-8.5-d11-legacy
+          - name: test-php-max-d11-stable
             php-version: 8.5
-            drupal-version: 11.3 # Lowest Drupal version that supports PHP 8.5.
+            drupal-version: 11
 
-          - name: test-php-8.5-d11-stable
-            php-version: 8.5
-            drupal-version: 11.3
+          - name: test-php-min-d11-legacy
+            php-version: 8.3
+            drupal-version: 11.1.0
 
-          - name: test-php-8.5-d11-canary
+          - name: test-php-max-d11-canary
             php-version: 8.5
             drupal-version: 11@beta
             stability: canary
@@ -158,6 +124,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Cache Composer dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -202,6 +170,7 @@ jobs:
 
       - name: Provision site
         run: .devtools/provision
+
 
       - name: Run tests
         working-directory: build

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.logs
 /build
 /composer.lock
+/node_modules
 /vendor
 
 # Ignore all Claude files by default. Custom files should be added explicitly.

--- a/.twig-cs-fixer.php
+++ b/.twig-cs-fixer.php
@@ -6,6 +6,10 @@ $ruleset = new TwigCsFixer\Ruleset\Ruleset();
 $ruleset->addStandard(new TwigCsFixer\Standard\Twig());
 
 $finder = new TwigCsFixer\File\Finder();
+// Extensions are symlinked into the build directory (each top-level item,
+// including templates/, is a symlink), so the Finder must follow symlinks to
+// discover the templates it needs to lint.
+$finder->followLinks();
 $finder->in(__DIR__ . '/web/modules/custom');
 $finder->in(__DIR__ . '/web/themes/custom');
 

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -6,11 +6,11 @@
         "drevops/phpcs-standard": "^0.6.2",
         "drupal/coder": "^8 || ^9",
         "drush/drush": "^12 || ^13",
-        "jangregor/phpstan-prophecy": "^1.0.2",
+        "jangregor/phpstan-prophecy": "^1.0.2 || ^2",
         "lullabot/mink-selenium2-driver": "^1.7 || ^2",
         "mglaman/phpstan-drupal": "^1.3.9 || ^2",
         "mikey179/vfsstream": "^1.6",
-        "palantirnet/drupal-rector": "^0.21.1",
+        "palantirnet/drupal-rector": "^1@beta",
         "phpcompatibility/php-compatibility": "^9.3.5 || ^10@alpha",
         "phpspec/prophecy-phpunit": "^2",
         "phpstan/extension-installer": "^1.4.3",
@@ -29,11 +29,6 @@
     },
     "extra": {
         "phpcodesniffer-search-depth": 10,
-        "patches": {},
-        "drupal-scaffold": {
-            "file-mapping": {
-                "[web-root]/.eslintrc.json": false
-            }
-        }
+        "patches": {}
     }
 }

--- a/docs.php
+++ b/docs.php
@@ -355,9 +355,7 @@ function dedent_code(string $code): string {
     return rtrim($code);
   }
 
-  $dedented = array_map(static function (string $line) use ($min_indent): string {
-    return strlen($line) >= $min_indent ? substr($line, $min_indent) : $line;
-  }, $lines);
+  $dedented = array_map(static fn(string $line): string => strlen($line) >= $min_indent ? substr($line, $min_indent) : $line, $lines);
 
   return rtrim(implode(PHP_EOL, $dedented));
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,12 +31,5 @@ parameters:
         - web/modules/custom/*
         - web/themes/custom/*
       reportUnmatched: false
-    -
-      # Drupal field magic properties are not visible to PHPStan.
-      message: '#Access to an undefined property#'
-      paths:
-        - web/modules/custom/*/tests/*
-        - web/themes/custom/*/tests/*
-      reportUnmatched: false
 
   reportUnmatchedIgnoredErrors: false

--- a/rector.php
+++ b/rector.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
 use DrupalRector\Set\Drupal10SetList;
+use DrupalRector\Set\Drupal11SetList;
 use DrupalRector\Set\Drupal9SetList;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
@@ -31,6 +32,7 @@ use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
 use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
@@ -55,6 +57,7 @@ return RectorConfig::configure()
     PrivatizeFinalClassPropertyRector::class,
     PrivatizeLocalGetterToPropertyRector::class,
     RemoveAlwaysTrueIfConditionRector::class,
+    RenameForeachValueVariableToMatchExprVariableRector::class,
     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
     RenameParamToMatchTypeRector::class,
     RenameVariableToMatchMethodCallReturnTypeRector::class,
@@ -62,39 +65,37 @@ return RectorConfig::configure()
     SimplifyEmptyCheckOnEmptyArrayRector::class,
     StringClassNameToClassConstantRector::class,
     // Directories to skip.
-    '*/vendor/*',
     '*/node_modules/*',
-    // Core and contribs.
-    '*/core/*',
-    '*/modules/contrib/*',
-    '*/themes/contrib/*',
-    '*/profiles/contrib/*',
-    // Files.
-    '*/sites/simpletest/*',
-    '*/sites/default/files/*',
-    // Composer scripts.
-    '*/scripts/composer/*',
   ])
   // PHP version upgrade sets - modernizes syntax to PHP 8.2.
   // Includes all rules from PHP 5.3 through 8.2.
   ->withPhpSets(php82: TRUE)
   // Code quality improvement sets.
   ->withPreparedSets(
+    deadCode: TRUE,
     codeQuality: TRUE,
     codingStyle: TRUE,
-    deadCode: TRUE,
-    naming: TRUE,
-    privatization: TRUE,
     typeDeclarations: TRUE,
+    privatization: TRUE,
+    naming: TRUE,
   )
   // Drupal-specific deprecation fixes.
   ->withSets([
     Drupal9SetList::DRUPAL_9,
     Drupal10SetList::DRUPAL_10,
+    Drupal11SetList::DRUPAL_11,
   ])
   // Additional rules.
   ->withRules([
     DeclareStrictTypesRector::class,
+  ])
+  // Paths to the extension's source. Each top-level item of the extension is
+  // symlinked individually into the build and Rector's finder does not follow
+  // symlinked directories, so the module children are matched directly (each is
+  // passed to the finder as its own root, which a symlinked root resolves).
+  ->withPaths([
+    __DIR__ . '/web/modules/custom/*/*',
+    __DIR__ . '/web/themes/custom/*/*',
   ])
   // Configure Drupal autoloading.
   ->withAutoloadPaths((function (): array {

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -36,15 +36,11 @@ class Helper {
 
   /**
    * Cached cloned service instances keyed by sandbox ID and service name.
-   *
-   * @var array
    */
   protected static array $instances = [];
 
   /**
    * Counter for generating unique sandbox IDs.
-   *
-   * @var int
    */
   protected static int $instanceId = 0;
 
@@ -169,7 +165,7 @@ class Helper {
       }
     }
 
-    if ($missing) {
+    if ($missing !== []) {
       throw new \RuntimeException(sprintf('Required modules not installed: %s.', implode(', ', $missing)));
     }
   }

--- a/src/Helpers/Menu.php
+++ b/src/Helpers/Menu.php
@@ -153,7 +153,7 @@ class Menu extends HelperBase {
   public function updateItem(string $menu_name, array $find_properties, array $updates): ?MenuLinkContentInterface {
     $link = $this->findItem($menu_name, $find_properties);
 
-    if ($link === NULL) {
+    if (!$link instanceof MenuLinkContentInterface) {
       $this->messenger->addWarning($this->t('Menu link not found in "@menu" — skipped update.', [
         '@menu' => $menu_name,
       ]));

--- a/src/Helpers/Redirect.php
+++ b/src/Helpers/Redirect.php
@@ -202,7 +202,8 @@ class Redirect extends HelperBase {
       }
 
       while (($row = fgetcsv($handle, escape: '\\')) !== FALSE) {
-        if (count($row) === 1 && trim((string) $row[0]) === '') {
+        $has_value = (bool) array_filter($row, static fn($value): bool => trim((string) $value) !== '');
+        if (!$has_value) {
           continue;
         }
 

--- a/src/Helpers/Redirect.php
+++ b/src/Helpers/Redirect.php
@@ -202,7 +202,7 @@ class Redirect extends HelperBase {
       }
 
       while (($row = fgetcsv($handle, escape: '\\')) !== FALSE) {
-        if (empty($row) || (count($row) === 1 && trim($row[0]) === '')) {
+        if (count($row) === 1 && trim((string) $row[0]) === '') {
           continue;
         }
 

--- a/src/Helpers/User.php
+++ b/src/Helpers/User.php
@@ -117,7 +117,7 @@ class User extends HelperBase {
   public function assignRoles(string $user_identifier, array $roles): void {
     $user = $this->findUser($user_identifier);
 
-    if ($user === NULL) {
+    if (!$user instanceof UserInterface) {
       $this->messenger->addWarning($this->t('User "@identifier" not found — skipped.', [
         '@identifier' => $user_identifier,
       ]));
@@ -152,7 +152,7 @@ class User extends HelperBase {
   public function removeRoles(string $user_identifier, array $roles): void {
     $user = $this->findUser($user_identifier);
 
-    if ($user === NULL) {
+    if (!$user instanceof UserInterface) {
       $this->messenger->addWarning($this->t('User "@identifier" not found — skipped.', [
         '@identifier' => $user_identifier,
       ]));

--- a/src/Traits/BatchTrait.php
+++ b/src/Traits/BatchTrait.php
@@ -16,15 +16,11 @@ trait BatchTrait {
 
   /**
    * The sandbox array, or NULL for non-batched operations.
-   *
-   * @var array|null
    */
   protected ?array $sandbox = NULL;
 
   /**
    * The batch size for batched operations.
-   *
-   * @var int
    */
   protected int $batchSize = 50;
 

--- a/tests/src/Kernel/HelperFacadeTest.php
+++ b/tests/src/Kernel/HelperFacadeTest.php
@@ -114,6 +114,7 @@ class HelperFacadeTest extends KernelTestBase {
   public function testRequirementCheckingPasses(): void {
     $instance = Helper::redirect();
 
+    /** @phpstan-ignore method.alreadyNarrowedType */
     $this->assertInstanceOf(Redirect::class, $instance);
   }
 

--- a/tests/src/Kernel/MenuHelperTest.php
+++ b/tests/src/Kernel/MenuHelperTest.php
@@ -21,8 +21,6 @@ class MenuHelperTest extends KernelTestBase {
 
   /**
    * The menu helper service.
-   *
-   * @var \Drupal\drupal_helpers\Helpers\Menu
    */
   protected Menu $menuHelper;
 

--- a/tests/src/Kernel/RedirectHelperTest.php
+++ b/tests/src/Kernel/RedirectHelperTest.php
@@ -172,6 +172,7 @@ class RedirectHelperTest extends KernelTestBase {
       $result = $helper->deleteAll();
     } while ($result === NULL);
 
+    /** @phpstan-ignore method.alreadyNarrowedType */
     $this->assertNotNull($result);
 
     // Reset entity cache and verify all deleted.
@@ -188,9 +189,9 @@ class RedirectHelperTest extends KernelTestBase {
     $csv_path = sys_get_temp_dir() . '/test_redirects_' . uniqid() . '.csv';
     $handle = fopen($csv_path, 'w');
     $this->assertIsResource($handle);
-    fputcsv($handle, escape: '\\', fields: ['csv-page-one', '/csv-target-one', '301']);
-    fputcsv($handle, escape: '\\', fields: ['csv-page-two', '/csv-target-two', '302']);
-    fputcsv($handle, escape: '\\', fields: ['csv-page-three', 'https://example.com', '301']);
+    fputcsv($handle, fields: ['csv-page-one', '/csv-target-one', '301'], escape: '\\');
+    fputcsv($handle, fields: ['csv-page-two', '/csv-target-two', '302'], escape: '\\');
+    fputcsv($handle, fields: ['csv-page-three', 'https://example.com', '301'], escape: '\\');
     fclose($handle);
 
     $result = $this->redirectHelper->importFromCsv($csv_path);
@@ -212,7 +213,7 @@ class RedirectHelperTest extends KernelTestBase {
     $handle = fopen($csv_path, 'w');
     $this->assertIsResource($handle);
     for ($i = 0; $i < 125; $i++) {
-      fputcsv($handle, escape: '\\', fields: ['csv-sandbox-page-' . $i, '/csv-sandbox-target-' . $i, '301']);
+      fputcsv($handle, fields: ['csv-sandbox-page-' . $i, '/csv-sandbox-target-' . $i, '301'], escape: '\\');
     }
     fclose($handle);
 
@@ -225,6 +226,7 @@ class RedirectHelperTest extends KernelTestBase {
       $result = $helper->importFromCsv($csv_path);
     } while ($result === NULL);
 
+    /** @phpstan-ignore method.alreadyNarrowedType */
     $this->assertNotNull($result);
 
     $storage = $this->container->get('entity_type.manager')->getStorage('redirect');

--- a/tests/src/Kernel/TermHelperTest.php
+++ b/tests/src/Kernel/TermHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\drupal_helpers\Kernel;
 
+use Drupal\taxonomy\TermInterface;
 use Drupal\drupal_helpers\Helpers\Term;
 use Drupal\KernelTests\KernelTestBase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -21,8 +22,6 @@ class TermHelperTest extends KernelTestBase {
 
   /**
    * The term helper service.
-   *
-   * @var \Drupal\drupal_helpers\Helpers\Term
    */
   protected Term $termHelper;
 
@@ -60,7 +59,7 @@ class TermHelperTest extends KernelTestBase {
 
     $this->assertCount(3, $terms);
 
-    $names = array_map(fn($term) => $term->getName(), $terms);
+    $names = array_map(fn(TermInterface $term) => $term->getName(), $terms);
     $this->assertContains('News', $names);
     $this->assertContains('Events', $names);
     $this->assertContains('Blog', $names);

--- a/tests/src/Kernel/UserHelperTest.php
+++ b/tests/src/Kernel/UserHelperTest.php
@@ -21,8 +21,6 @@ class UserHelperTest extends KernelTestBase {
 
   /**
    * The user helper service.
-   *
-   * @var \Drupal\drupal_helpers\Helpers\User
    */
   protected User $userHelper;
 

--- a/tests/src/Unit/BatchTraitTest.php
+++ b/tests/src/Unit/BatchTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\drupal_helpers\Unit;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
@@ -28,14 +29,14 @@ class BatchTraitTest extends TestCase {
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface&\PHPUnit\Framework\MockObject\MockObject
    */
-  protected EntityTypeManagerInterface $entityTypeManager;
+  protected MockObject $entityTypeManager;
 
   /**
    * The messenger mock.
    *
    * @var \Drupal\Core\Messenger\MessengerInterface&\PHPUnit\Framework\MockObject\MockObject
    */
-  protected MessengerInterface $messenger;
+  protected MockObject $messenger;
 
   /**
    * The test helper instance using BatchTrait.
@@ -54,9 +55,7 @@ class BatchTraitTest extends TestCase {
     $this->helper = new BatchTraitTestHelper($this->entityTypeManager, $this->messenger);
 
     $translation = $this->createMock(TranslationInterface::class);
-    $translation->method('translateString')->willReturnCallback(function ($input) {
-      return (string) $input->getUntranslatedString();
-    });
+    $translation->method('translateString')->willReturnCallback(fn($input): string => (string) $input->getUntranslatedString());
     $this->helper->setStringTranslation($translation);
   }
 
@@ -139,17 +138,20 @@ class BatchTraitTest extends TestCase {
     // Second call: items 51-100.
     $result = $this->helper->batch($items, $callback, 'records');
     $this->assertNull($result);
+    /** @phpstan-ignore method.impossibleType */
     $this->assertCount(100, $processed);
 
     // Third call: items 101-120 (final).
     $this->messenger->expects($this->once())->method('addStatus');
     $result = $this->helper->batch($items, $callback, 'records');
     $this->assertNotNull($result);
+    /** @phpstan-ignore method.impossibleType */
     $this->assertCount(120, $processed);
     $this->assertStringContainsString('120', $result);
     $this->assertStringContainsString('records', $result);
 
     // Verify all items were processed in order.
+    /** @phpstan-ignore method.impossibleType */
     $this->assertSame($items, $processed);
   }
 
@@ -204,7 +206,7 @@ class BatchTraitTest extends TestCase {
     $items = ['a', 'b', 'c'];
     $captured_contexts = [];
 
-    $callback = function ($item, array $context) use (&$captured_contexts): void {
+    $callback = function (string $item, array $context) use (&$captured_contexts): void {
       $this->assertArrayHasKey('index', $context);
       $this->assertArrayHasKey('total', $context);
       $this->assertArrayHasKey('results', $context);


### PR DESCRIPTION
## Summary

Updated the project infrastructure to drupal_extension_scaffold 4.17.0 via `init.php`, retaining the project's selected tool set (PHPCS, PHPStan, Rector, Twig CS Fixer, PHPUnit, FunctionalJavascript, Renovate) and omitting the JS/CSS tooling (eslint, stylelint, cspell, jest) that was removed in a prior release. The updated scaffold tightened PHPStan rules and introduced a newer Rector ruleset, so all PHPStan findings were addressed and Rector auto-refactorings were applied across the codebase. Scaffold-only example stubs that this minimal helper module does not use were removed, the project's `php docs.php --fail-on-change` lint step was restored, and orphaned Node.js setup left in the CI lint job was removed (this is a PHP-only project). Verified locally with `ahoy build`, `ahoy lint`, and `ahoy test` (166 tests, 786 assertions), and all CI matrix jobs (PHP 8.2-8.5 x Drupal 10/11) are green.

## Changes

**Scaffold infrastructure (`init.php` output)**
- `.devtools/info` - new read-only diagnostics script resolving PHP/Drupal/Composer/Drush/Node versions, webserver host/port (with source tracking), XDebug state, build dir, database path, and Drupal profile; wired up as `ahoy info` (alias `describe`).
- `.devtools/helpers.php`, `.devtools/start`, `.devtools/stop`, `.devtools/provision`, `.devtools/README.md` - centralized webserver resolution helpers and post-phase custom-script hooks.
- `.claude/settings.json` - committed the scaffold-provided Claude Code permissions allowlist (`ahoy:*`, `composer:*`); tracked via the scaffold's `.gitignore` rule.
- `.ahoy.yml` - added `info`/`describe` command and `debug` wiring via `.devtools/info xdebug`.
- `composer.dev.json` - bumped `jangregor/phpstan-prophecy` to `^1.0.2 || ^2` and `palantirnet/drupal-rector` to `^1@beta`; removed the now-unneeded `.eslintrc.json` scaffold override.
- `rector.php`, `phpstan.neon`, `.editorconfig`, `.gitignore`, `.twig-cs-fixer.php` - updated tool configs from the new scaffold.
- `.gitattributes` - re-added `docs.php export-ignore` (dropped by the generic scaffold) so the dev-only docs generator stays out of distribution archives; removed stale JS/CSS tool entries.

**Removed scaffold example stubs** (not used by this minimal helper module)
- Example `drupal_helpers.module`/`.install`/`.routing.yml`/`.libraries.yml`/`.links.menu.yml`, `css/`, `js/`, `config/`, `scripts/`, `package.json`/`package-lock.json`, and example service/form/test classes.

**Branch references**
- `.github/workflows/test.yml`, `draft-release-notes.yml` - changed the scaffold default branch `1.x` to the project's `2.x`.

**CI lint job fix**
- `.github/workflows/test.yml` - removed the orphaned `Setup Node.js` and `npm ci --ignore-scripts` steps from the `lint` job. The scaffold left them in place even though all JS tooling is dropped, so `npm ci` failed in CI (no `package-lock.json`). The lint job now runs only the PHP tools (PHPCS, PHPStan, Rector, Twig CS Fixer), matching the project's JS-free configuration.

**Restored project lint step**
- `.ahoy.yml` - restored the `php docs.php --fail-on-change` step in the `lint` command, which the generic scaffold `.ahoy.yml` had dropped. The README API reference is generated by `docs.php`, so this verification is part of the project's lint.

**PHPStan findings and Rector refactorings (`src/`, `tests/`, `docs.php`)**
- `src/Helpers/Redirect.php` - removed the dead `empty($row)` branch (`fgetcsv` never returns an empty array), and now skips a CSV row only when every column is empty after trim, via `array_filter($row, ...)`, so multi-column all-empty rows (e.g. `,`) no longer create empty redirects.
- `src/Helpers/Menu.php`, `src/Helpers/User.php` - `=== NULL` guards replaced with `instanceof` type guards (Rector).
- `src/Helper.php`, `src/Traits/BatchTrait.php` - removed redundant typed `@var` docblock tags; `$missing !== []` instead of a truthy check.
- `tests/src/Kernel/HelperFacadeTest.php`, `RedirectHelperTest.php`, `tests/src/Unit/BatchTraitTest.php` - added targeted `@phpstan-ignore method.alreadyNarrowedType` / `method.impossibleType` annotations (matching the project's existing convention) for assertions the stricter PHPStan cannot prove against runtime state (loop-guaranteed non-null, narrowed return types, by-reference batch counters); applied Rector refactorings (closures to arrow functions, typed closure parameters, named-argument sorting in `fputcsv`).
- `docs.php` - closure-to-arrow-function Rector refactoring (no change to generated output; README stays in sync).

## Before / After

```
Lint job (.github/workflows/test.yml)
─────────────────────────────────────────────────────────────
Before (scaffold 4.17.0 init output)   After (this PR)
  Checkout                               Checkout
  Setup Node.js            ◀── removed   Cache Composer deps
  npm ci --ignore-scripts ◀── removed    Setup PHP
  Cache Composer deps                    Assemble
  Setup PHP                              PHPCS / PHPStan / Rector / Twig CS
  Assemble
  PHPCS / PHPStan / Rector / Twig CS
  (npm ci fails: no package-lock.json)   (PHP-only: matches JS-free project)

Repository layout
─────────────────────────────────────────────────────────────
Before (scaffold example output)       After (minimal helper module)
  drupal_helpers.{module,install,        drupal_helpers.{info,services}.yml
    routing,libraries,links.menu}.yml    src/Helper.php + Helpers/ + Traits/
  src/ + src/Form/ + DrupalHelpers...    tests/ (Unit + Kernel)
  tests/ (Unit/Kernel/Functional/        docs.php, logo.png, README.md
    FunctionalJavascript) + stubs        + PHP tool configs
  css/ js/ config/ scripts/             [removed] css/ js/ config/ scripts/
  package.json package-lock.json        [removed] package*.json + example stubs
```
